### PR TITLE
chore(security): enable Renovate for GitHub Actions SHA pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}


### PR DESCRIPTION
## Summary

Enable Renovate to manage GitHub Actions SHA pinning for this repository.

## What changed

- Adds `.github/renovate.json5` extending the shared WandB Renovate preset
- No workflow files are changed

## What happens next

After this merges, Renovate should open a follow-up PR that pins GitHub Actions `uses:` references to immutable commit SHAs while preserving readable version comments.
